### PR TITLE
allow navigation on touch devices

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -73,6 +73,19 @@ async function start() {
     ];
   });
 
+  function updatePosition(deltaX, deltaY) {
+    position.value = [
+      Math.min(
+        SIZE * cellSize - screenWidth.value,
+        Math.max(0, position.value[0] + deltaX)
+      ),
+      Math.min(
+        SIZE * cellSize - screenHeight.value,
+        Math.max(0, position.value[1] + deltaY)
+      ),
+    ];
+  }
+
   function resizeScreen() {
     screenWidth.value = window.innerWidth;
     screenHeight.value = window.innerHeight;
@@ -292,16 +305,7 @@ async function start() {
   });
 
   on(canvas, "wheel", (e) => {
-    position.value = [
-      Math.min(
-        SIZE * cellSize - screenWidth.value,
-        Math.max(0, position.value[0] + e.deltaX)
-      ),
-      Math.min(
-        SIZE * cellSize - screenHeight.value,
-        Math.max(0, position.value[1] + e.deltaY)
-      ),
-    ];
+    updatePosition(e.deltaX, e.deltaY);
   });
 
   on(window, "resize", resizeScreen);

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -86,6 +86,11 @@ async function start() {
     ];
   }
 
+  function updateCursorPosition(e) {
+    let gridPos = projectMouse(e);
+    cursorCell.value = [gridPos[0] | 0, gridPos[1] | 0];
+  }
+
   function resizeScreen() {
     screenWidth.value = window.innerWidth;
     screenHeight.value = window.innerHeight;
@@ -300,8 +305,7 @@ async function start() {
   });
 
   on(canvas, "mousemove", (e) => {
-    let gridPos = projectMouse(e);
-    cursorCell.value = [gridPos[0] | 0, gridPos[1] | 0];
+    updateCursorPosition(e);
   });
 
   on(canvas, "wheel", (e) => {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -58,6 +58,7 @@ async function start() {
   let screenHeight = signal(0);
   let viewportWidth = computed(() => Math.ceil(screenWidth.value / cellSize));
   let viewportHeight = computed(() => Math.ceil(screenHeight.value / cellSize));
+  let lastTouchEvent = null;
 
   const tilesCanvas = generateTiles();
 
@@ -306,6 +307,21 @@ async function start() {
 
   on(canvas, "mousemove", (e) => {
     updateCursorPosition(e);
+  });
+
+  on(canvas, "touchmove", (e) => {
+    const currentTouch = e.changedTouches[0];
+
+    if (lastTouchEvent && currentTouch) {
+      const deltaX = lastTouchEvent.clientX - currentTouch.clientX;
+      const deltaY = lastTouchEvent.clientY - currentTouch.clientY;
+      updatePosition(deltaX, deltaY);
+      updateCursorPosition(currentTouch);
+    }
+    lastTouchEvent = currentTouch;
+  });
+  on(canvas, "touchend", () => {
+    lastTouchEvent = null;
   });
 
   on(canvas, "wheel", (e) => {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -1,3 +1,8 @@
+html,
+body {
+  overscroll-behavior: none;
+}
+
 #grid {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
Feel free to make changes/discard as you see fit!

## Problem

On desktop, navigation across the canvas is done via wheel events. On touch devices, wheel events don't fire, making it so you can't navigate around the canvas.

In addition, pulling down on iOS devices triggers a window refresh.

## Solution

Set up `touchmove` and `touchend` events to track movement requests.

For window refresh, add CSS to prevent it.

## Caveats

Tested in ios simulator. Not tested on a real ios device or an android device/simulator.